### PR TITLE
Cache previously bundled modules with level.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "iframe": "0.0.2",
     "browser-request": "0.2.0",
     "inherits": "1.0.0",
-    "detective": "~2.1.2"
+    "detective": "~2.1.2",
+    "browser-module-cache": "0.1.1"
   },
   "engines": {
     "node": "0.8.x"


### PR DESCRIPTION
Uses https://github.com/shama/browser-module-cache to cache browserify-cdn bundled modules with level.js. Thanks!
