### PR TITLE
When script is undefined concat using empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ Sandbox.prototype.bundle = function(entry, preferredVersions) {
   }
   
   function makeIframe(script) {
-    script = script + entry
+    script = (script || '') + entry
     // setTimeout is because iframes report inaccurate window.innerWidth/innerHeight, even after DOMContentLoaded!
     var body = self.iframeBody +
         '<script type="text/javascript" src="data:text/javascript;charset=UTF-8,'


### PR DESCRIPTION
Just to make sure things play nice when no modules are required.